### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # It will report linting issues without failing the build and enforce test coverage requirements
 
 name: Python CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jpwhite3/phoney/security/code-scanning/6](https://github.com/jpwhite3/phoney/security/code-scanning/6)

To fix the problem, explicitly set the `permissions` key at the workflow level (top-level, just after `name:` and before `on:`) to restrict the `GITHUB_TOKEN` to the minimal required permissions. For most CI workflows that only need to check out code and upload artifacts, `contents: read` is sufficient. If any job needs more (e.g., to comment on pull requests), those jobs can override the permissions block. In this case, none of the jobs appear to require write access, so setting `permissions: contents: read` at the workflow level is the best fix. This change should be made at the top of `.github/workflows/python-package.yml`, after the `name:` key and before the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
