### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/jpwhite3/phoney/security/code-scanning/2](https://github.com/jpwhite3/phoney/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the workflow. Since only the release step requires `contents: write`, but the rest of the steps only need `read`, the simplest and safest fix is to add a `permissions` block at the job level for the `build` job, specifying `contents: write`. This ensures the job has only the permissions it needs, and does not rely on potentially broader repository defaults. The `permissions` block should be added as a sibling to `runs-on` (i.e., at the same indentation level).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
